### PR TITLE
docker-compose updates to fix assorted issues

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,4 +1,31 @@
 version: "3.9"
+
+# common env var settings
+# not all containers use all of these env vars, but they are common
+# enough it's much simpler to track them in one place
+x-common-variables: &common-variables
+  JAMBONES_MYSQL_HOST: 172.10.0.2
+  JAMBONES_MYSQL_USER: jambones
+  JAMBONES_MYSQL_PASSWORD: jambones
+  JAMBONES_MYSQL_DATABASE: jambones
+  # different servers require these env vars a little differently, but
+  # probably at least the first two can be consolidated soon
+  JWT_SECRET: '5a3e38b5-3188-4936-89c9-fb0df3138b5c'
+  ENCRYPTION_SECRET: '5a3e38b5-3188-4936-89c9-fb0df3138b5c'
+  AUTHENTICATION_KEY: '5a3e38b5-3188-4936-89c9-fb0df3138b5c'
+  NODE_ENV: production
+  JAMBONES_TIME_SERIES_HOST: 172.10.0.61
+  ENABLE_METRICS: 0
+  JAMBONES_CLUSTER_ID: jb
+  JAMBONES_REDIS_HOST: 172.10.0.3
+  JAMBONES_REDIS_PORT: 6379
+  JAMBONES_LOGLEVEL: info
+  # note that DRACHTIO_HOST is different for the feature server,
+  # so we set it explicitly on the containers that need it
+  DRACHTIO_PORT: 9022
+  DRACHTIO_SECRET: cymru
+
+
 networks:
   jambonz:
     driver: bridge
@@ -12,7 +39,7 @@ services:
       - ./data_volume:/var/lib/mysql
     ports:
       - "3360:3306"
-    environment: 
+    environment:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
       MYSQL_DATABASE: "jambones"
       MYSQL_USER: "jambones"
@@ -20,7 +47,7 @@ services:
     healthcheck:
       test: ["CMD", "mysqladmin" ,"ping", "-h", "127.0.0.1", "--protocol", "tcp"]
       timeout: 5s
-      retries: 10    
+      retries: 10
     networks:
       jambonz:
         ipv4_address: 172.10.0.2
@@ -36,11 +63,12 @@ services:
   drachtio-sbc:
     image: drachtio/drachtio-server:latest
     restart: always
-    command: drachtio --contact sip:172.10.0.10;transport=udp --external-ip ${HOST_IP} --contact sip:172.10.0.10;transport=tcp --address 0.0.0.0 --port 9022
+    command: ["drachtio", "--contact", "sip:172.10.0.10;transport=udp,tcp",  "--external-ip",  "${HOST_IP}", "--address", "0.0.0.0", "--port", "9022", "--disable-nat-detection"]
     volumes:
       - ./sbc/drachtio.conf.xml:/etc/drachtio.conf.xml
     ports:
       - "5060:5060/udp"
+      - "5060:5060/tcp"
     depends_on:
       - rtpengine
     networks:
@@ -50,7 +78,7 @@ services:
   rtpengine:
     image: drachtio/rtpengine:jambonz-test
     restart: always
-    command: rtpengine --interface private/172.10.0.11 --interface public/172.10.0.11!${HOST_IP} --log-level 7
+    command: ["rtpengine", "--interface", "private/172.10.0.11", "--interface", "public/172.10.0.11!${HOST_IP}", "--log-level", "5"]
     ports:
       - "40000-40100:40000-40100/udp"
     networks:
@@ -63,27 +91,17 @@ services:
     ports:
       - "3000:3000"
     environment:
-      NODE_ENV: production
-      JWT_SECRET: '5a3e38b5-3188-4936-89c9-fb0df3138b5c'
-      JAMBONES_MYSQL_HOST: 172.10.0.2
-      JAMBONES_MYSQL_USER: jambones 
-      JAMBONES_MYSQL_PASSWORD: jambones 
-      JAMBONES_MYSQL_DATABASE: jambones 
-      JAMBONES_REDIS_HOST: 172.10.0.3
-      JAMBONES_REDIS_PORT: 6379
-      JAMBONES_LOGLEVEL: info
-      JAMBONE_API_VERSION: v1 
-      JAMBONES_CLUSTER_ID: jb 
-      ENABLE_METRICS: 0
+      <<: *common-variables
       HTTP_PORT: 3000
-      JAMBONES_TIME_SERIES_HOST: 172.10.0.61
     depends_on:
-      - mysql
-      - redis
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
     networks:
       jambonz:
         ipv4_address: 172.10.0.30
-    
+
   webapp:
     build: ./jambonz-webapp
     networks:
@@ -100,42 +118,33 @@ services:
     image: jambonz/sbc-registrar:latest
     restart: always
     environment:
-      NODE_ENV: production
+      <<: *common-variables
       DRACHTIO_HOST: 172.10.0.10
-      DRACHTIO_PORT: 9022
-      DRACHTIO_SECRET: cymru
-      JAMBONES_MYSQL_HOST: 172.10.0.2
-      JAMBONES_MYSQL_USER: jambones 
-      JAMBONES_MYSQL_PASSWORD: jambones 
-      JAMBONES_MYSQL_DATABASE: jambones 
-      JAMBONES_REDIS_HOST: 172.10.0.3
-      JAMBONES_REDIS_PORT: 6379
-      JAMBONES_LOGLEVEL: info
-      ENABLE_METRICS: 0
-      JAMBONES_TIME_SERIES_HOST: 172.10.0.61
     depends_on:
-      - mysql
-      - redis
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
     networks:
       jambonz:
         ipv4_address: 172.10.0.32
-  
+
   call-router:
     image: jambonz/sbc-call-router:latest
     restart: always
     environment:
-      NODE_ENV: production
+      <<: *common-variables
       DOCKER_BRIDGE_IP: 172.10.0.1
-      JAMBONES_LOGLEVEL: info
       JAMBONES_NETWORK_CIDR: 172.10.0.0/16
       HTTP_PORT: 4000
       JAMBONES_INBOUND_ROUTE: 127.0.0.1:4002
       JAMBONES_OUTBOUND_ROUTE: 127.0.0.1:4003
       JAMBONZ_TAGGED_INBOUND: 1
-      ENABLE_METRICS: 0
     depends_on:
-      - mysql
-      - redis
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
     networks:
       jambonz:
         ipv4_address: 172.10.0.33
@@ -144,26 +153,17 @@ services:
     image: jambonz/sbc-inbound:latest
     restart: always
     environment:
-      NODE_ENV: production
+      <<: *common-variables
+      NODE_ENV: test
       DRACHTIO_HOST: 172.10.0.10
-      DRACHTIO_PORT: 9022
-      DRACHTIO_SECRET: cymru
       JAMBONES_RTPENGINES: '172.10.0.11:22222'
-      JAMBONES_MYSQL_HOST: 172.10.0.2
-      JAMBONES_MYSQL_USER: jambones 
-      JAMBONES_MYSQL_PASSWORD: jambones 
-      JAMBONES_MYSQL_DATABASE: jambones 
-      JAMBONES_REDIS_HOST: 172.10.0.3
-      JAMBONES_REDIS_PORT: 6379
-      JAMBONES_CLUSTER_ID: jb 
-      JAMBONES_LOGLEVEL: info
-      ENABLE_METRICS: 0
       JAMBONES_NETWORK_CIDR: 172.10.0.0/16
-      JAMBONES_TIME_SERIES_HOST: 172.10.0.61
-      ENCRYPTION_SECRET: 'supersecret'
+      JAMBONES_FEATURE_SERVERS: 172.10.0.50:5060
     depends_on:
-      - mysql
-      - redis
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
     networks:
       jambonz:
         ipv4_address: 172.10.0.34
@@ -172,25 +172,15 @@ services:
     image: jambonz/sbc-outbound:latest
     restart: always
     environment:
-      NODE_ENV: production
+      <<: *common-variables
       DRACHTIO_HOST: 172.10.0.10
-      DRACHTIO_PORT: 9022
-      DRACHTIO_SECRET: cymru
       JAMBONES_RTPENGINES: '172.10.0.11:22222'
-      JAMBONES_MYSQL_HOST: 172.10.0.2
-      JAMBONES_MYSQL_USER: jambones 
-      JAMBONES_MYSQL_PASSWORD: jambones 
-      JAMBONES_MYSQL_DATABASE: jambones 
-      JAMBONES_REDIS_HOST: 172.10.0.3
-      JAMBONES_REDIS_PORT: 6379
-      JAMBONES_CLUSTER_ID: jb 
-      JAMBONES_LOGLEVEL: info
-      ENABLE_METRICS: 0
       JAMBONES_NETWORK_CIDR: 172.10.0.0/16
-      JAMBONES_TIME_SERIES_HOST: 172.10.0.61
     depends_on:
-      - mysql
-      - redis
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_started
     networks:
       jambonz:
         ipv4_address: 172.10.0.35
@@ -198,7 +188,7 @@ services:
   drachtio-fs:
     image: drachtio/drachtio-server:latest
     restart: always
-    command: drachtio --contact sip:*;transport=udp,tcp --address 0.0.0.0 --port 9022
+    command: ["drachtio", "--contact", "sip:*;transport=udp", "--contact", "sip:*;transport=tcp", "--address", "0.0.0.0", "--port", "9022"]
     networks:
       jambonz:
         ipv4_address: 172.10.0.50
@@ -206,7 +196,7 @@ services:
   freeswitch:
     image: drachtio/drachtio-freeswitch-mrf:0.4.27
     restart: always
-    command: freeswitch --rtp-range-start 20000 --rtp-range-end 20100
+    command: ["freeswitch", "--rtp-range-start", "20000", "--rtp-range-end", "20100"]
     ports:
       - "8022:8021/tcp"
     volumes:
@@ -222,29 +212,14 @@ services:
       - ./credentials:/opt/credentials
       - ./tmpAudio:/tmp
     environment:
-      NODE_ENV: production
+      <<: *common-variables
       GOOGLE_APPLICATION_CREDENTIALS: /opt/credentials/gcp.json
       DRACHTIO_HOST: 172.10.0.50
-      DRACHTIO_PORT: 9022
-      DRACHTIO_SECRET: cymru
-      JAMBONES_MYSQL_HOST: 172.10.0.2
-      JAMBONES_MYSQL_USER: jambones 
-      JAMBONES_MYSQL_PASSWORD: jambones 
-      JAMBONES_MYSQL_DATABASE: jambones 
-      JAMBONES_REDIS_HOST: 172.10.0.3
-      JAMBONES_REDIS_PORT: 6379
-      JAMBONES_LOGLEVEL: info
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY}
-      AWS_REGION: ${AWS_REGION}
-      ENABLE_METRICS: 0
       JAMBONES_NETWORK_CIDR: 172.10.0.0/16
       HTTP_PORT: 3000
       JAMBONES_SBCS: 172.10.0.10
       JAMBONES_FEATURE_SERVERS: 172.10.0.50:9022:cymru
-      JAMBONES_FREESWITCH: 172.10.0.51:8021:ClueCon
-      JAMBONES_TIME_SERIES_HOST: 172.10.0.61
-      ENCRYPTION_SECRET: 'supersecret'
+      JAMBONES_FREESWITCH: 172.10.0.51:8021:JambonzR0ck$
     depends_on:
       - mysql
       - redis
@@ -264,5 +239,3 @@ services:
     networks:
       jambonz:
         ipv4_address: 172.10.0.61
-
-


### PR DESCRIPTION
- change all multi-token commands to use lists instead of strings: in some cases special characters were interpreted by the shell, and so the full command arguments were interpreted. this resulted in the system not being able to correctly ACK incoming calls, in turn causing calls to hang up after 30 seconds

- change NODE_ENV to test for sbc-inbound: with NODE_ENV set to production for the sbc-inbound, feature server registration does not happen quite right with the redis host, causing calls to bounce

- merge common environment variables: since many of the containers share the same env vars, this merges those together in a common section which simplifies updating and debugging these settings